### PR TITLE
fix: Fix working directory settings😓

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,4 +14,4 @@ endif ()
 
 add_test (NAME colortest
           COMMAND colortest
-          WORKING DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
**OOPS** wrong keyword!

Why `CMake` don't treat it as an error?